### PR TITLE
version 1.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Imports:
     jsonlite,
     lubridate,
     httr,
-    purrr
+    purrr,
+    curl
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.0.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gbfs
 Type: Package
 Title: Interface with General Bikeshare Feed Specification Files
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: c(
     person("Kaelyn", "Rosenberg", , "kaerosenberg@gmail.com", c("aut")),
     person("Simon P.", "Couch", , "simonpatrickcouch@gmail.com", c("aut", "cre")),

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -4,6 +4,12 @@ output: github_document
 
 # News
 
+### 1.3.1
+
+* All package functions requiring internet access now immediately check 
+the internet connection upon being called, raising a message and returning 
+an empty list if an internet connection is not available.
+
 ### 1.3.0
 
 * The main wrapper function, `get_gbfs`, can now return its output as a named 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # News
 
+### 1.3.1
+
+  - All package functions requiring internet access now immediately
+    check the internet connection upon being called, raising a message
+    and returning an empty list if an internet connection is not
+    available.
+
 ### 1.3.0
 
   - The main wrapper function, `get_gbfs`, can now return its output as

--- a/R/get_gbfs.R
+++ b/R/get_gbfs.R
@@ -9,7 +9,7 @@
 get_gbfs_cities <- function() {
   
   # test internet connection
-  if (!curl::has_internet()) {
+  if (!connected_to_internet()) {
     return(message_no_internet())
   }
   
@@ -56,7 +56,7 @@ get_gbfs_cities <- function() {
 get_which_gbfs_feeds <- function(city) {
     
   # test internet connection
-  if (!curl::has_internet()) {
+  if (!connected_to_internet()) {
     return(message_no_internet())
   }
   
@@ -125,7 +125,7 @@ get_which_gbfs_feeds <- function(city) {
 get_gbfs <- function(city, feeds = "all", directory = NULL, output = NULL) {
 
   # test internet connection
-  if (!curl::has_internet()) {
+  if (!connected_to_internet()) {
     return(message_no_internet())
   }
   

--- a/R/get_gbfs.R
+++ b/R/get_gbfs.R
@@ -6,7 +6,14 @@
 #' @source North American Bikeshare Association, General Bikeshare Feed Specification
 #'  \url{https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv}
 #' @export
-  get_gbfs_cities <- function() {
+get_gbfs_cities <- function() {
+  
+  # test internet connection
+  if (!curl::has_internet()) {
+    return(message_no_internet())
+  }
+  
+  # specify column types
   systems_cols <- readr::cols(
     `Country Code` = readr::col_character(),
     "Name" = readr::col_character(),
@@ -16,6 +23,7 @@
     `Auto-Discovery URL` = readr::col_character()
   )
   
+  # grab the data
   readr::read_csv("https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv",
                   col_types = systems_cols)
 }
@@ -47,13 +55,22 @@
 #' @export
 get_which_gbfs_feeds <- function(city) {
     
-    url <- city_to_url(city, "gbfs")
+  # test internet connection
+  if (!curl::has_internet()) {
+    return(message_no_internet())
+  }
+  
+  # convert the city argument to a URL
+  url <- city_to_url(city, "gbfs")
     
-    gbfs <- jsonlite::fromJSON(txt = url)
+  # grab the relevant data
+  gbfs <- jsonlite::fromJSON(txt = url)
     
-    gbfs_feeds <- gbfs[[3]][[1]][[1]]
+  # pull out the dataset
+  gbfs_feeds <- gbfs[[3]][[1]][[1]]
     
-    return(gbfs_feeds)
+  # ...and return it!
+  return(gbfs_feeds)
     
 }
   
@@ -107,6 +124,11 @@ get_which_gbfs_feeds <- function(city) {
 #' @export
 get_gbfs <- function(city, feeds = "all", directory = NULL, output = NULL) {
 
+  # test internet connection
+  if (!curl::has_internet()) {
+    return(message_no_internet())
+  }
+  
   # check the "feeds" argument
   feeds <- process_feeds_argument(feeds)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,7 @@ city_to_url <- function(city_, feed_) {
       return(city_)
     } else {
       stop(sprintf(c("The supplied argument for \"city\" looks like a URL, ",
-                     "but the webpage doesn't seem to exist. Please check",
+                     "but the webpage doesn't seem to exist. Please check ",
                      "the URL provided or provide the city name as a string.")))
     }
   }
@@ -163,7 +163,7 @@ determine_output_types <- function(directory_, output_) {
 get_gbfs_dataset_ <- function(city, directory, file, output, feed) {
   
   # test internet connection
-  if (!curl::has_internet()) {
+  if (!connected_to_internet()) {
     return(message_no_internet())
   }
   
@@ -347,10 +347,13 @@ url_exists <- function(x, quiet = FALSE, ...) {
   sHEAD <- safely(httr::HEAD)
   sGET <- safely(httr::GET)
   
+  if (!stringr::str_detect(x, "http")) {
+    x <- paste0("https://", x)
+  }
+  
   res <- sHEAD(x, ...)
   
-  if (is.null(res$result) || 
-      ((httr::status_code(res$result) %/% 200) != 1)) {
+  if (is.null(res$result)) {
     
     res <- sGET(x, ...)
     
@@ -369,4 +372,9 @@ message_no_internet <- function() {
   message(c("You don't seem to have an active internet connection. Please", 
             "connect to the internet to use the gbfs package."))
   return(list())
+}
+
+# a wrapper around has internet so that with_mock can be used in tests
+connected_to_internet <- function() {
+  curl::has_internet()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,6 +162,11 @@ determine_output_types <- function(directory_, output_) {
 # a function that grabs a gbfs formatted dataset
 get_gbfs_dataset_ <- function(city, directory, file, output, feed) {
   
+  # test internet connection
+  if (!curl::has_internet()) {
+    return(message_no_internet())
+  }
+  
   # check arguments to make sure the putput method makes sense
   check_return_arguments(directory_ = directory,
                          file_ = file,
@@ -356,4 +361,12 @@ url_exists <- function(x, quiet = FALSE, ...) {
   
   return(TRUE)
   
+}
+
+# a function to alert the user of no internet connection in a
+# more informative/helpful way
+message_no_internet <- function() {
+  message(c("You don't seem to have an active internet connection. Please", 
+            "connect to the internet to use the gbfs package."))
+  return(list())
 }

--- a/cran-comments.Rmd
+++ b/cran-comments.Rmd
@@ -8,7 +8,18 @@ output: github_document
 * win-builder (devel and release)
 
 ## R CMD check results
-There were no ERRORs, WARNINGs, or NOTEs. 
+There were no ERRORs or WARNINGs.
+
+There was 1 NOTE (from win-builder):
+
+> checking CRAN incoming feasibility ... NOTE
+  
+> Maintainer: 'Simon P. Couch <simonpatrickcouch@gmail.com>'
+  
+> Days since last update: 1
+  
+This package is being submitted so soon after a recent update in order  to 
+address a unit test error from `r-patched-solaris-x86` on CRAN servers.
 
 ## Downstream dependencies
 There are currently no downstream dependencies for this package.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,7 +7,19 @@
 
 ## R CMD check results
 
-There were no ERRORs, WARNINGs, or NOTEs.
+There were no ERRORs or WARNINGs.
+
+There was 1 NOTE (from win-builder):
+
+> checking CRAN incoming feasibility … NOTE
+
+> Maintainer: ‘Simon P. Couch <simonpatrickcouch@gmail.com>’
+
+> Days since last update: 1
+
+This package is being submitted so soon after a recent update in order
+to address a unit test error from `r-patched-solaris-x86` on CRAN
+servers.
 
 ## Downstream dependencies
 

--- a/tests/testthat/test-dynamic-feeds.R
+++ b/tests/testthat/test-dynamic-feeds.R
@@ -3,6 +3,8 @@ context("dynamic feeds")
 
 test_that("dynamic feeds work", {
   
+  skip_if_offline(host = "r-project.org")
+  
   get_station_status("portland")
   
   get_free_bike_status("portland")
@@ -10,6 +12,8 @@ test_that("dynamic feeds work", {
 })
 
 test_that("file saving and overwriting works", {
+  
+  skip_if_offline(host = "r-project.org")
   
   # make a temporary directory
   dir <- tempdir()
@@ -23,6 +27,8 @@ test_that("file saving and overwriting works", {
 })
 
 test_that("row binding checks work", {
+  
+  skip_if_offline(host = "r-project.org")
   
   # make a temporary directory
   dir <- tempdir()

--- a/tests/testthat/test-static-feeds.R
+++ b/tests/testthat/test-static-feeds.R
@@ -3,6 +3,8 @@ context("static feeds")
 
 test_that("static feeds work", {
   
+  skip_if_offline(host = "r-project.org")
+  
   get_station_information("portland")
   
   get_system_alerts("portland")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -3,6 +3,8 @@ context("utils")
 
 test_that("argument checking works", {
   
+  skip_if_offline(host = "r-project.org")
+  
   # bad argument to `output`
   expect_error(check_return_arguments(directory_ = NULL,
                                       file_ = "gbfs.Rds",
@@ -44,11 +46,13 @@ test_that("argument checking works", {
   # feeds argument is valid
   expect_error(process_feeds_argument("bop"),
                "argument is \"bop\", but it needs")
-  
     
 })
 
 test_that("find feed from top level works", {
+  
+  skip_if_offline(host = "r-project.org")
+  
   expect_equal(find_feed_from_top_level(
                  "http://biketownpdx.socialbicycles.com/opendata/gbfs.json",
                  "station_information"),
@@ -89,3 +93,27 @@ test_that("determine output type works", {
   
 })
 
+test_that("no internet connection message works", {
+  
+  # "pretend" that the internet connection doesn't work
+  with_mock("gbfs::connected_to_internet" = function() FALSE,
+  
+  # try it on all of the different functions that test internet connection
+    expect_message(get_gbfs("portland")),
+  
+    expect_message(get_gbfs_dataset_("portland", 
+                                   NULL, 
+                                   NULL, 
+                                   "return", 
+                                   "station_information")),
+  
+    expect_message(get_which_gbfs_feeds("portland")),
+  
+    expect_message(get_gbfs_cities()),
+  
+    expect_equal(get_gbfs_cities(),
+                 list())
+  
+  
+  )
+})

--- a/tests/testthat/test-wrapper.R
+++ b/tests/testthat/test-wrapper.R
@@ -9,12 +9,16 @@ biketown <- get_gbfs("portland")
 
 test_that("main wrapper works", {
  
+  skip_if_offline(host = "r-project.org")
+  
   expect_equal(class(biketown), "list")
   
 })
 
 test_that("argument checking works", {
 
+  skip_if_offline(host = "r-project.org")
+  
   # no directory supplied but user wants to save
   expect_error(get_gbfs("portland", 
                         output = "save"),


### PR DESCRIPTION
Addresses a unit test error on CRAN's `r-patched-solaris-x86` server--all package functions requiring internet access now immediately check the internet connection upon being called, raising a message and returning an empty list if an internet connection is not available.